### PR TITLE
Adding Power support(ppc64le) with continuous integration/testing so that project stays architecture independent.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+arch:
+  - amd64
+  - ppc64le
 
 go:
   - tip
@@ -8,7 +11,8 @@ go:
   - "1.11.13"
   - "1.10.8"
   - "1.9.7"
-
+  
+go_import_path: github.com/coyim/otr3/
 matrix:
   allow_failures:
     - go: tip


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, 
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

